### PR TITLE
Undefined name: Typo -- "OVERWRTIE" --> "OVERWRITE"

### DIFF
--- a/buildpdf.py
+++ b/buildpdf.py
@@ -419,7 +419,7 @@ def fetch_resources(uri, rel):
 def createpdf_pisa(pagename):
     "creates a pdf file from a saved page using pisa (python module)"
     import ho.pisa as pisa
-    if (not exists(pagename+".pdf",image=True)) or OVERWRTIE:
+    if (not exists(pagename+".pdf",image=True)) or OVERWRITE:
         infile = open(FOLDER + os.sep + pagename+'.html','ro')
         outfile = open(FOLDER + os.sep + pagename+'.pdf','wb')
         if VERBOSE: print("Converting " + pagename + " to pdf...")


### PR DESCRIPTION
Transposed the I and T...

[flake8](http://flake8.pycqa.org) testing of https://github.com/FreeCAD/FreeCAD-Doc on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./buildqhelp.py:71:7: F821 undefined name 'raw_input'
    i=raw_input("Copy the files to their correct location in the source tree? y/n (default=no) ")
      ^
./buildpdf.py:422:52: F821 undefined name 'OVERWRTIE'
    if (not exists(pagename+".pdf",image=True)) or OVERWRTIE:
                                                   ^
2     F821 undefined name 'OVERWRTIE'
2
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree